### PR TITLE
Correct initialization assertion

### DIFF
--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -65,7 +65,7 @@ struct AprilTagNode::AprilTagsImpl {
                   const uint32_t height, const size_t image_buffer_size,
                   const size_t pitch_bytes,
                   const sensor_msgs::msg::CameraInfo::ConstSharedPtr &msg_ci) {
-    assert(april_tags_handle != nullptr), "Already initialized.";
+    assert(april_tags_handle == nullptr && "Already initialized.");
 
     // Get camera intrinsics
     const double *k = msg_ci->k.data();


### PR DESCRIPTION
The assertion made before initializing the `AprilTagNode` is reversed from what it should be. Since the goal is to avoid re-initialization, we should assert that the current value of the handle is `nullptr`.